### PR TITLE
Add Matchering to Open source instruments/effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ These are the software tools that I find useful in my audio programming.
 - [AirWindows Plugins](https://github.com/airwindows/airwindows) - A large collection of GUI-less plug-ins open source but supported via patreon [see airwindows site](http://www.airwindows.com/)
 - [Temper](https://github.com/creativeintent/temper) - A digital distortion built using JUCE and FAUST
 - [zita stuff](http://kokkinizita.linuxaudio.org/linuxaudio/index.html) - Fons Adriaensen's linux audio projects offer a lot of great tools for acoustic measurements, spatial audio etc - mostly as jack apps.
+- [matchering](https://github.com/sergree/matchering) - A python library and dockerized web app for automated reference audio mastering.
 
 ## Machine Learning / MIR
 - [GuitarML](https://github.com/GuitarML) - Very cool project building open source guitar fx/amp simulations using machine learning techniques.


### PR DESCRIPTION
Hey, Oli. Nice to meet you!

I'd like to suggest adding [Matchering] to Open source instruments/effects.
[Matchering] is an Python library and Dockerized Web App for automated reference audio mastering.

You can think of it like a fully-automated Mid-Side version of iZotope Match EQ on steriods.
It is made in Python using only popular open source libraries like Numpy or Scipy.
[It can be connected to any python app using pip.](https://github.com/sergree/matchering#quick-example)
[It can be used from the command line for batch processing.](https://github.com/sergree/matchering-cli)
Also it has [the web version, which is the open source alternative](https://github.com/sergree/matchering-web) to such paid online mastering services like [LANDR], [eMastered], etc.

It works in the back-end of such popular apps as [Moises](https://moises.ai/) and [Songmastr](https://www.songmastr.com/).

Thanks for your time!

[matchering]: https://github.com/sergree/matchering
[LANDR]: https://www.landr.com/
[eMastered]: https://emastered.com/