### PR TITLE
Add FreeEQ8 to Exemplary open source audio plug-in projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ These are the software tools that I find useful in my audio programming.
 - [surge](https://github.com/surge-synthesizer/surge) - Surge was an excellent product which has been open sourced and is now being maintained and continually improved by the surge-synth team, with a new JUCE UI.
 - [valentine](https://github.com/Tote-Bag-Labs/valentine) - An awesome compressor and great, complete project example for a cross platform audio plug-in in 2023.
 - [vital](https://github.com/mtytel/vital) - Vital is a very succesful wavetable synth with a slick interface done using the GPU. Amazing that a project like this can be open source!
+- [FreeEQ8](https://github.com/GareBear99/FreeEQ8) - A free, GPL-3 JUCE-based 8-band parametric EQ with linear phase (overlap-add FFT convolution), per-band dynamic EQ, match EQ, M/S processing, and 1×–8× oversampling. The repo ships a Milestone-A RT-safety pass: pooled oversamplers with zero heap allocation on the audio thread, a swap-chain triple-buffered spectrum FIFO and FIR kernel handoff, and a standalone test suite that proves the invariants under concurrent stress. A useful reference for realistic real-time-safe plug-in architecture.
 
 ## Miscellaneous open source audio code/projects
 


### PR DESCRIPTION
Hi Oli — adding FreeEQ8 under *Exemplary open source audio plug-in projects* alongside surge / valentine / vital.

FreeEQ8 is a free, GPL-3 8-band parametric EQ built with JUCE (VST3 / AU / Standalone) and its "pro" sibling ProEQ8 is a 24-band commercial build from the same source. I think it may be a useful reference for this list specifically because of the recent Milestone-A real-time-safety pass:

- Pooled oversamplers with **zero heap allocation on the audio thread** on order change (A1).
- Canonical **swap-chain triple buffer** for the spectrum-analyzer FIFO (A4) and for the linear-phase FIR kernel handoff (A5) — classic `writeSlot` / `midSlot` / `readSlot` permutation-of-{0,1,2} pattern.
- Linear-phase FIR rebuild moved to a dedicated `juce::Thread` worker — no FFT work on the audio thread.
- Standalone test suite (no JUCE deps) that proves the invariants under concurrent stress: 3 runs × 400 ms, ~600 M samples, 0 tears. Plus a micro-bench harness.
- Full writeup and benchmarks are committed in `docs/MILESTONE_A_REPORT.md`.

Repo: https://github.com/GareBear99/FreeEQ8
Milestone-A report: https://github.com/GareBear99/FreeEQ8/blob/main/docs/MILESTONE_A_REPORT.md

Happy to trim the description or move it under *Miscellaneous open source audio code/projects* if that fits better.